### PR TITLE
Inject data only when renders via Meteor

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -26,7 +26,8 @@ http.OutgoingMessage.prototype.write = function(chunk, encoding) {
   var condition =
     this._injectPayload && !this._injected &&
     encoding === undefined &&
-    /<!DOCTYPE html>/.test(chunk);
+    /<!DOCTYPE html>/.test(chunk) &&
+    /Content-Type: text\/html/.test(this._header);
 
   if(condition) {
     // if cors headers included if may cause some security holes


### PR DESCRIPTION
Look for text/html in the content type on the request to better decide when to inject fast render data.
