### PR TITLE
Fix bug where data would be injected inside conditional IE tags

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -48,7 +48,7 @@ http.OutgoingMessage.prototype.write = function(chunk, encoding) {
 
     // if this is a buffer, convert it to string
     chunk = chunk.toString();
-    chunk = chunk.replace('<script', injectHtml + '<script');
+    chunk = chunk.replace('</body>', injectHtml + '</body>');
 
     this._injected = true;
   }


### PR DESCRIPTION
Hi,

I have a `.html` file that conditionally loads styles and scripts for IE9, e.g.

```
<!--[if lt IE 9]>
  <script src="/js/event-polyfill.min.js"></script>
  <script src="/js/html5shiv.min.js"></script>
  <script src="/js/respond.min.js"></script>
  <script src="/js/calc.min.js"></script>
<![endif]-->
```

Inject data was injecting the data inside the `<!--[if lt IE 9]>` causing all sorts of issues.

I've changed the code so that rather than jumping in before a `<script>` tag it just gets added at the end of the `<body>` tag.

It fixes my problem and I can't see that it would cause any others?

On an unrelated note I've also got a local version of inject-data that doesn't require jQuery - happy to do a PR for that if it's of any use.
