### PR TITLE
Eliminate dependencies on jquery, and underscore.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,14 @@
 Meteor.startup(function() {
-  var dom = $('script[type="text/inject-data"]', document);
-  var injectedDataString = $.trim(dom.text());
+  var injectedDataString = ""
+  var scriptTags = document.getElementsByTagName("script");
+
+  for (var i = 0; i < scriptTags.length; i++) {
+    if (scriptTags[i].getAttribute("type") == "text/inject-data") {
+      injectedDataString = scriptTags[i].innerHTML.replace(/(^\s+|\s+$)/g, "");
+      break;
+    }
+  }
+
   InjectData._data = InjectData._decode(injectedDataString) || {};
 });
 

--- a/lib/inject.html
+++ b/lib/inject.html
@@ -1,1 +1,0 @@
-<script type="text/inject-data"><%= data %></script>

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,9 +1,6 @@
 var http = Npm.require('http');
 
-var templateText = Assets.getText('lib/inject.html');
-var injectDataTemplate = _.template(templateText);
-
-// custome API
+// custom API
 InjectData.pushData = function pushData(res, key, value) {
   if(!res._injectPayload) {
     res._injectPayload = {};
@@ -15,7 +12,9 @@ InjectData.pushData = function pushData(res, key, value) {
 
 InjectData.getData = function getData(res, key) {
   if(res._injectPayload) {
-    return _.clone(res._injectPayload[key]);
+    var data = res._injectPayload[key];
+    var clonedData = EJSON.parse(EJSON.stringify(data));
+    return clonedData;
   } else {
     return null;
   }
@@ -50,7 +49,7 @@ InjectData._hijackWriteIfNeeded = function(res) {
 
       // inject data
       var data = InjectData._encode(res._injectPayload);
-      var injectHtml = injectDataTemplate({data: data});
+      var injectHtml = '<script type="text/inject-data">' + data + '</script>';
 
       // if this is a buffer, convert it to string
       chunk = chunk.toString();

--- a/package.js
+++ b/package.js
@@ -38,11 +38,6 @@ function configure (api) {
   api.versionsFrom('METEOR@0.9.3');
 
   api.use('ejson', ['server', 'client']);
-  api.use('underscore', 'server');
-
-  api.addFiles([
-    'lib/inject.html',
-  ], 'server', {isAsset: true});
 
   api.addFiles([
     'lib/namespace.js',

--- a/package.js
+++ b/package.js
@@ -37,8 +37,8 @@ Package.onTest(function(api) {
 function configure (api) {
   api.versionsFrom('METEOR@0.9.3');
 
-  api.use(['ejson', 'underscore'], ['server', 'client']);
-  api.use('jquery', 'client');
+  api.use('ejson', ['server', 'client']);
+  api.use('underscore', 'server');
 
   api.addFiles([
     'lib/inject.html',

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -39,9 +39,11 @@ Tinytest.add(
     };
 
     Picker.route(path, function(params, req, res, next) {
-      _.each(sendingData, function(val, key) {
-        InjectData.pushData(res, key, val);
-      });
+      for (var key in sendingData) {
+        if (sendingData.hasOwnProperty(key)) {
+          console.log(key, sendingData[key]);
+        }
+      }
       next();
     });
 

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -41,7 +41,7 @@ Tinytest.add(
     Picker.route(path, function(params, req, res, next) {
       for (var key in sendingData) {
         if (sendingData.hasOwnProperty(key)) {
-          console.log(key, sendingData[key]);
+          InjectData.pushData(res, key, sendingData[key]);
         }
       }
       next();
@@ -132,7 +132,8 @@ function getInjectedData(path) {
   var url = urlResolve(process.env.ROOT_URL, path);
   var res = HTTP.get(url);
 
-  var matched = res.content.match(/data">(.*)<\/script/);
+  var matched = res.content.match(/data">(.*?)<\/script/);
+
   if(matched) {
     var encodedData = matched[1];
     return InjectData._decode(encodedData);


### PR DESCRIPTION
I don't think we should need all of jquery just for a couple of methods.
We could simplify this with `document.querySelector` if we don't care about IE <= 7.

I don't think underscore is used on the client, so I've removed that dependency too.
Does this look good?
