### PR TITLE
Mark files with `<!DOCTYPE html>` at the start as HTML

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -32,7 +32,7 @@ InjectData._hijackWriteIfNeeded = function(res) {
     var condition =
       res._injectPayload && !res._injected &&
       encoding === undefined &&
-      /<!DOCTYPE html>/.test(chunk);
+      /^<!DOCTYPE html>/.test(chunk);
 
     if(condition) {
       // if cors headers included if may cause some security holes


### PR DESCRIPTION
A Javascript file could also contain the string `<!DOCTYPE html>` and InjectData would then modify that file. This is actually the case for the [Froala text editor](https://www.froala.com/wysiwyg-editor).

 In other words: This change prevents our production app from blowing up.
