### PR TITLE
Fix for TypeError (crashes server)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -38,7 +38,7 @@ InjectData._hijackWriteIfNeeded = function(res) {
       // if cors headers included if may cause some security holes
       // so we simply turn off injecting if we detect an cors header
       // read more: http://goo.gl/eGwb4e
-      if(res._headers['access-control-allow-origin']) {
+      if(res._headers && res._headers['access-control-allow-origin']) {
         var warnMessage =
           'warn: injecting data turned off due to CORS headers. ' +
           'read more: http://goo.gl/eGwb4e';


### PR DESCRIPTION
`TypeError: Cannot read property 'access-control-allow-origin' of null`. It's related to this thread: https://github.com/meteorhacks/inject-data/issues/10.